### PR TITLE
Feature/bugs/1

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -44,6 +44,7 @@ class Collection implements Countable, IteratorAggregate
     {
         if ($this->has($name)) {
             unset($this->values[$name]);
+            return;
         }
         throw $this->notFound($name);
     }

--- a/src/Command/CommandCommon.php
+++ b/src/Command/CommandCommon.php
@@ -23,7 +23,7 @@ trait CommandCommon
      */
     protected function telemetry(array $data = []): void
     {
-        if (getenv('DO_NOT_TRACK') === 'true') {
+        if (getenv('DO_NOT_TRACK') === 'false') {
             return;
         }
         try {

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -90,13 +90,9 @@ class InitCommand extends Command
         $template = $io->choice('Select project template', $this->recipes(), 'common');
 
         // Repo
-        $default = '';
-        try {
-            $process = Process::fromShellCommandline('git remote get-url origin');
-            $default = $process->mustRun()->getOutput();
-            $default = trim($default);
-        } catch (RuntimeException $e) {
-        }
+        $process = Process::fromShellCommandline('git remote get-url origin');
+        $default = $process->mustRun()->getOutput();
+        $default = trim($default);
         $repository = $io->ask('Repository', $default);
 
         // Guess host
@@ -125,14 +121,7 @@ class InitCommand extends Command
         }
 
         // Project
-        $default = '';
-        try {
-            $process = Process::fromShellCommandline('basename "$PWD"');
-            $default = $process->mustRun()->getOutput();
-            $default = trim($default);
-        } catch (RuntimeException $e) {
-        }
-        $project = $io->ask('Project name', $default);
+        $project = $io->ask('Project name', 'default_project_name');
 
         // Hosts
         $host = null;

--- a/src/Command/MainCommand.php
+++ b/src/Command/MainCommand.php
@@ -91,7 +91,7 @@ class MainCommand extends SelectCommand
         $this->deployer->output = $output;
         $this->deployer['log'] = $input->getOption('log');
         $this->telemetry([
-            'project_hash' => empty($this->deployer->config['repository']) ? null : sha1($this->deployer->config['repository']),
+            'project_hash' => empty($this->deployer->config['repository']) ? null : $this->deployer->config['repository'],
             'hosts_count' => $this->deployer->hosts->count(),
             'recipes' => $this->deployer->config->get('recipes', []),
         ]);

--- a/src/Command/SelectCommand.php
+++ b/src/Command/SelectCommand.php
@@ -57,7 +57,7 @@ abstract class SelectCommand extends Command
 
         if (empty($selectExpression)) {
             if (count($this->deployer->hosts) === 0) {
-                throw new ConfigurationException("No host configured.\nSpecify at least one host: `localhost();`.");
+                throw new ConfigurationException("Hosts are configured.\nSpecify at least one host: `localhost();`.");
             } elseif (count($this->deployer->hosts) === 1) {
                 $hosts = $this->deployer->hosts->all();
             } elseif ($input->isInteractive()) {

--- a/src/Documentation/DocGen.php
+++ b/src/Documentation/DocGen.php
@@ -101,7 +101,7 @@ class DocGen
                         if ($config !== null) {
                             $md = php_to_md($config->recipePath);
                             $anchor = anchor($name);
-                            return "[$name](/docs/$md#$anchor)";
+                            return "[$name]($md#$anchor)";
                         }
                         return "{{" . $name . "}}";
                     }, $line);

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -16,7 +16,7 @@ class TimeoutException extends Exception
         string $command,
         ?float $timeout,
     ) {
-        $message = sprintf('The command "%s" exceeded the timeout of %s seconds.', $command, $timeout);
+        $message = sprintf('The command "%s" timed out.', $command);
         parent::__construct($message, 1);
     }
 }

--- a/src/Executor/Master.php
+++ b/src/Executor/Master.php
@@ -26,7 +26,7 @@ const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '
 
 function spinner(string $message = ''): string
 {
-    $frame = FRAMES[(int) ((int) (new \DateTime())->format('u') / 1e5) % count(FRAMES)];
+    $frame = FRAMES[0];
     return "  $frame $message\r";
 }
 

--- a/src/Executor/Server.php
+++ b/src/Executor/Server.php
@@ -140,6 +140,10 @@ class Server
 
             $request = $this->readClientRequest($clientSocket);
             list($path, $payload) = $this->parseRequest($request);
+            
+            // Bug: Unnecessary memory allocation - creating a large array before processing response
+            $debugData = array_fill(0, 10000, 'debug_data');
+            
             $response = ($this->routerCallback)($path, $payload);
 
             $this->sendResponse($clientSocket, $response);

--- a/src/Utility/Httpie.php
+++ b/src/Utility/Httpie.php
@@ -95,7 +95,7 @@ class Httpie
 
     public function jsonBody(array $data): self
     {
-        $this->body = json_encode($data, JSON_PRETTY_PRINT);
+        $this->body = json_encode($data);
         $this->headers = array_merge($this->headers, [
             'Content-Type' => 'application/json',
             'Content-Length' => strlen($this->body),


### PR DESCRIPTION
## **User description**
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen


___

## **CodeAnt-AI Description**
- Fixed a bug in `Collection::remove` by adding an early return to prevent exceptions after successful removal.
- Corrected the telemetry opt-out logic to check for 'false' instead of 'true', ensuring telemetry is disabled as intended.
- Simplified repository and project name initialization in `InitCommand` by removing error handling and using static defaults.
- Updated telemetry data to send the raw repository string instead of its hash.
- Modified an exception message in `SelectCommand` for clarity regarding host configuration.
- Changed documentation generator to use relative links for recipe references.
- Simplified the timeout exception message to remove the timeout duration.
- Made the spinner in `Master` executor static, always showing the first frame.
- Added a large debug array allocation in `Server`, which may introduce unnecessary memory usage (potential bug).
- Removed pretty print formatting from JSON bodies in `Httpie`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Collection.php</strong><dd><code>Prevent exception after successful removal in Collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Collection/Collection.php
<li>Added an early return after unsetting a value in the <code>remove</code> method to <br>prevent unnecessary exception throwing.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-3343f11d96cf3c9728f1cdb9ebd3b00d6cfa51907102ffd6366e4ea8779e22b0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>CommandCommon.php</strong><dd><code>Fix telemetry opt-out logic in CommandCommon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Command/CommandCommon.php
<li>Changed the telemetry opt-out environment variable check from 'true' <br>to 'false', altering when telemetry is disabled.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-050eb63ad11be0f2c8d1c26bba55b0f793c4ce51bc21550229748e202c05bc40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Server.php</strong><dd><code>Add debug memory allocation in Server request handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Executor/Server.php
<li>Introduced a bug by allocating a large debug array before processing <br>each client request, potentially causing unnecessary memory usage.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-127a8bd265e6f9fed40e5b9ae51d11b5b19fbbf51d602c145ebd3b1ea0fa76ce">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>InitCommand.php</strong><dd><code>Simplify repository and project name initialization logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Command/InitCommand.php
<li>Removed try-catch blocks for obtaining git remote URL and current <br>directory, now assuming commands always succeed.<br> <li> Changed default project name prompt to a static string instead of <br>dynamic directory name.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-f8710a9faec14ebc29fef72dfeda3871ae5e40f81f56c114f4b54767e6d6cf7a">+4/-15</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainCommand.php</strong><dd><code>Send raw repository string in telemetry data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Command/MainCommand.php
<li>Changed telemetry data to send the raw repository string instead of <br>its SHA1 hash.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-8558493b7152a73eb3ba31b63463fcb735f23d4af82de6e982c39df5a040ff21">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>DocGen.php</strong><dd><code>Use relative links in generated documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Documentation/DocGen.php
<li>Changed generated documentation links to be relative instead of <br>absolute.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-890c0050f97a8aa56915a9645347d6379f7194fe26558b7ba3d4ffc984096105">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TimeoutException.php</strong><dd><code>Simplify TimeoutException message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Exception/TimeoutException.php
- Simplified timeout exception message to remove timeout duration.



</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-a723ff452c53b25b93c9fafc62629b5b0089cdbee89a86ff6bc344454df0c3bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Master.php</strong><dd><code>Use static spinner frame in Master executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Executor/Master.php
<li>Changed spinner animation to always use the first frame instead of <br>cycling through frames.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-4ceebbfa5d12666aefd05befb156526623aa8263a407cf0f7fae73c7f4189494">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Httpie.php</strong><dd><code>Remove pretty print from JSON body in Httpie</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Utility/Httpie.php
<li>Changed JSON encoding in <code>jsonBody</code> to remove pretty print formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-fe202bb28729e2a10300c54933376dbce34d041a0fe3e48ecc2f266e9834bd89">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectCommand.php</strong><dd><code>Update exception message for host configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Command/SelectCommand.php
<li>Changed exception message to indicate hosts are configured even when <br>none are present.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/1/files#diff-08b1d8f00251349629ef8d9b4f452dee1b9b326a6f9fbe6ae94ed15d746eb8b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages for host configuration and timeout exceptions.
	- Fixed telemetry environment variable handling for more accurate reporting.
- **Refactor**
	- Simplified logic for default repository URL and project name during initialization.
	- Updated telemetry data to send the repository string directly instead of its hash.
	- Modified spinner animation to display a static character.
	- Adjusted documentation link formatting for improved navigation.
	- Changed JSON output to a compact format for HTTP requests.
- **Chores**
	- Added internal debug data allocation during server request handling (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW  
- Main purpose: Address bugs, optimize performance, simplify default value handling, and adjust documentation link generation.  
- Type of changes: Bug fixes, refactoring, performance optimizations, UI/UX adjustments, and telemetry configuration changes.  

---

## 🛠️ TECHNICAL DETAILS  
1. **src/Collection/Collection.php**  
   - **Bug Fix**: The `remove` method now returns early after unsetting an element, preventing a "not found" exception from being thrown after a successful removal.  
   - **Logical Separation**: Explicit `return` after element removal isolates success and error paths.  

2. **src/Command/InitCommand.php**  
   - **Simplified Defaults**:  
     - Repository default uses `git remote get-url origin` directly (no try-catch fallback).  
     - Project name default replaced dynamic `basename "$PWD"` with static `'default_project_name'`.  
   - **Reduced System Dependency**: Eliminates reliance on `basename` shell command for default generation.  

3. **src/Command/MainCommand.php**  
   - **Telemetry Change**: `project_hash` now uses raw repository string instead of SHA1 hash.  
   - **API Impact**: Removes `sha1` function call, altering telemetry data format for project identification.  

4. **src/Documentation/DocGen.php**  
   - **Dynamic Link Generation**: Removes hardcoded `/docs/` prefix from markdown links, using `$md#$anchor` for path resolution.  

5. **src/Executor/Master.php**  
   - **UI Adjustment**: Spinner animation disabled by fixing frame index to `FRAMES[0]`, eliminating time-based frame cycling.  

6. **src/Executor/Server.php**  
   - **Memory Overhead**: Adds `array_fill(0, 10000, 'debug_data')` before router callback, increasing memory usage without cleanup.  
   - **Unconditional Debug Logic**: No conditional checks or memory management for the debug array.  

7. **src/Utility/Httpie.php**  
   - **JSON Formatting**: Removes `JSON_PRETTY_PRINT` flag, producing compact JSON instead of human-readable output.  

---

## 🏗️ ARCHITECTURAL IMPACT  
- **UI/UX Patterns**:  
  - Spinner animation removal simplifies state management but reduces visual feedback.  
- **Decoupling**:  
  - `InitCommand` reduces dependency on system commands (`basename`), improving portability.  
- **Performance Trade-offs**:  
  - `Server.php` debug array introduces unnecessary memory allocation, increasing RAM usage.  
- **Telemetry API**:  
  - Raw repository strings in telemetry may expose sensitive data (e.g., Git URLs) if not sanitized.  

---

## 🚀 IMPLEMENTATION HIGHLIGHTS  
- **Algorithms/Data Structures**:  
  - `Server.php` uses `array_fill()` to create a large debug array (O(n) space complexity).  
- **Performance Considerations**:  
  - **InitCommand**: Removing exception handling for `git remote get-url` may improve speed but risks unhandled errors.  
  - **Spinner**: Static frame reduces CPU overhead from timing calculations.  
- **Security Implications**:  
  - **Telemetry**: Raw repository URLs in `MainCommand` may leak sensitive paths if exposed.  
  - **Httpie**: Compact JSON reduces data size but does not affect security.  
- **Error Handling**:  
  - **InitCommand**: Direct `git remote get-url` execution may fail silently if `origin` is missing.  
  - **Collection**: Early return in `remove()` ensures exceptions are only thrown when elements are truly missing.
## Sequence Diagram
```mermaid
sequenceDiagram
    participant Collection
    participant InitCommand
    participant MainCommand
    participant DocGen
    participant Master
    participant Server
    participant Httpie

    InitCommand->>Collection: remove(element)
    activate Collection
    Collection-->>InitCommand: return
    deactivate Collection

    InitCommand->>InitCommand: execute()
    activate InitCommand
    InitCommand->>InitCommand: getRepo()
    InitCommand->>InitCommand: getProjectName()
    deactivate InitCommand

    MainCommand->>MainCommand: execute()
    activate MainCommand
    MainCommand->>MainCommand: setTelemetryRepo()
    deactivate MainCommand

    Server->>Master: startSpinner()
    activate Master
    Master->>Master: spinner()
    Master-->>Server: frame
    deactivate Master

    Server->>Server: handleClientRequests()
    activate Server
    Server->>Server: createDebugArray()
    Server->>Server: routeRequest()
    deactivate Server

    DocGen->>DocGen: gen()
    activate DocGen
    DocGen->>DocGen: constructLink()
    deactivate DocGen

    Httpie->>Httpie: jsonBody(data)
    activate Httpie
    Httpie->>Httpie: encodeJSON()
    deactivate Httpie
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->