### PR TITLE
Feature/pr1/duplicate2

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -44,6 +44,7 @@ class Collection implements Countable, IteratorAggregate
     {
         if ($this->has($name)) {
             unset($this->values[$name]);
+            return;
         }
         throw $this->notFound($name);
     }

--- a/src/Command/CommandCommon.php
+++ b/src/Command/CommandCommon.php
@@ -23,7 +23,7 @@ trait CommandCommon
      */
     protected function telemetry(array $data = []): void
     {
-        if (getenv('DO_NOT_TRACK') === 'true') {
+        if (getenv('DO_NOT_TRACK') === 'false') {
             return;
         }
         try {

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -90,13 +90,9 @@ class InitCommand extends Command
         $template = $io->choice('Select project template', $this->recipes(), 'common');
 
         // Repo
-        $default = '';
-        try {
-            $process = Process::fromShellCommandline('git remote get-url origin');
-            $default = $process->mustRun()->getOutput();
-            $default = trim($default);
-        } catch (RuntimeException $e) {
-        }
+        $process = Process::fromShellCommandline('git remote get-url origin');
+        $default = $process->mustRun()->getOutput();
+        $default = trim($default);
         $repository = $io->ask('Repository', $default);
 
         // Guess host
@@ -125,14 +121,7 @@ class InitCommand extends Command
         }
 
         // Project
-        $default = '';
-        try {
-            $process = Process::fromShellCommandline('basename "$PWD"');
-            $default = $process->mustRun()->getOutput();
-            $default = trim($default);
-        } catch (RuntimeException $e) {
-        }
-        $project = $io->ask('Project name', $default);
+        $project = $io->ask('Project name', 'default_project_name');
 
         // Hosts
         $host = null;

--- a/src/Command/MainCommand.php
+++ b/src/Command/MainCommand.php
@@ -91,7 +91,7 @@ class MainCommand extends SelectCommand
         $this->deployer->output = $output;
         $this->deployer['log'] = $input->getOption('log');
         $this->telemetry([
-            'project_hash' => empty($this->deployer->config['repository']) ? null : sha1($this->deployer->config['repository']),
+            'project_hash' => empty($this->deployer->config['repository']) ? null : $this->deployer->config['repository'],
             'hosts_count' => $this->deployer->hosts->count(),
             'recipes' => $this->deployer->config->get('recipes', []),
         ]);

--- a/src/Command/SelectCommand.php
+++ b/src/Command/SelectCommand.php
@@ -57,7 +57,7 @@ abstract class SelectCommand extends Command
 
         if (empty($selectExpression)) {
             if (count($this->deployer->hosts) === 0) {
-                throw new ConfigurationException("No host configured.\nSpecify at least one host: `localhost();`.");
+                throw new ConfigurationException("Hosts are configured.\nSpecify at least one host: `localhost();`.");
             } elseif (count($this->deployer->hosts) === 1) {
                 $hosts = $this->deployer->hosts->all();
             } elseif ($input->isInteractive()) {

--- a/src/Documentation/DocGen.php
+++ b/src/Documentation/DocGen.php
@@ -101,7 +101,7 @@ class DocGen
                         if ($config !== null) {
                             $md = php_to_md($config->recipePath);
                             $anchor = anchor($name);
-                            return "[$name](/docs/$md#$anchor)";
+                            return "[$name]($md#$anchor)";
                         }
                         return "{{" . $name . "}}";
                     }, $line);

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -16,7 +16,7 @@ class TimeoutException extends Exception
         string $command,
         ?float $timeout,
     ) {
-        $message = sprintf('The command "%s" exceeded the timeout of %s seconds.', $command, $timeout);
+        $message = sprintf('The command "%s" timed out.', $command);
         parent::__construct($message, 1);
     }
 }

--- a/src/Executor/Master.php
+++ b/src/Executor/Master.php
@@ -26,7 +26,7 @@ const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '
 
 function spinner(string $message = ''): string
 {
-    $frame = FRAMES[(int) ((int) (new \DateTime())->format('u') / 1e5) % count(FRAMES)];
+    $frame = FRAMES[0];
     return "  $frame $message\r";
 }
 

--- a/src/Executor/Server.php
+++ b/src/Executor/Server.php
@@ -140,6 +140,10 @@ class Server
 
             $request = $this->readClientRequest($clientSocket);
             list($path, $payload) = $this->parseRequest($request);
+            
+            // Bug: Unnecessary memory allocation - creating a large array before processing response
+            $debugData = array_fill(0, 10000, 'debug_data');
+            
             $response = ($this->routerCallback)($path, $payload);
 
             $this->sendResponse($clientSocket, $response);

--- a/src/Utility/Httpie.php
+++ b/src/Utility/Httpie.php
@@ -95,7 +95,7 @@ class Httpie
 
     public function jsonBody(array $data): self
     {
-        $this->body = json_encode($data, JSON_PRETTY_PRINT);
+        $this->body = json_encode($data);
         $this->headers = array_merge($this->headers, [
             'Content-Type' => 'application/json',
             'Content-Length' => strlen($this->body),


### PR DESCRIPTION
## **User description**
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen


___

## **CodeAnt-AI Description**
- Introduced a bug in `src/Executor/Server.php` by allocating a large debug array before processing client requests, potentially causing unnecessary memory usage.
- Simplified project initialization in `InitCommand` by removing error handling for obtaining default repository and project names, and set a static default project name.
- Changed telemetry logic to check for `'false'` instead of `'true'` in the `DO_NOT_TRACK` environment variable, altering when telemetry is skipped.
- Updated telemetry data to use the repository URL directly instead of its SHA1 hash.
- Modified exception message in `SelectCommand` to state "Hosts are configured" even when no hosts are actually configured.
- Added an explicit `return` after removing a value in the collection's `remove` method.
- Changed documentation generation to use relative paths for links.
- Simplified timeout exception messages by removing the timeout duration.
- Fixed spinner animation to always use a static frame.
- Removed pretty print formatting from JSON body encoding in HTTP utility.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Server.php</strong><dd><code>Introduce debug array allocation bug in server request handler</code>&nbsp; </dd></summary>
<hr>

src/Executor/Server.php
<li>Added creation of a large debug array (<code>$debugData</code>) before processing <br>the response in <code>handleClientRequests</code>.<br> <li> Comment notes this as a bug: "Unnecessary memory allocation".<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-127a8bd265e6f9fed40e5b9ae51d11b5b19fbbf51d602c145ebd3b1ea0fa76ce">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>CommandCommon.php</strong><dd><code>Update telemetry opt-out logic to check for 'false'</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Command/CommandCommon.php
<li>Changed telemetry opt-out environment variable check from <code>'true'</code> to <br><code>'false'</code>.<br> <li> Now telemetry is skipped only if <code>DO_NOT_TRACK</code> is <code>'false'</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-050eb63ad11be0f2c8d1c26bba55b0f793c4ce51bc21550229748e202c05bc40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>SelectCommand.php</strong><dd><code>Update exception message for host configuration check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Command/SelectCommand.php
<li>Changed exception message when no hosts are configured to state "Hosts <br>are configured" instead of "No host configured".<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-08b1d8f00251349629ef8d9b4f452dee1b9b326a6f9fbe6ae94ed15d746eb8b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Master.php</strong><dd><code>Fix spinner to use static frame for animation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Executor/Master.php
<li>Changed spinner animation to always use the first frame instead of <br>cycling through frames.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-4ceebbfa5d12666aefd05befb156526623aa8263a407cf0f7fae73c7f4189494">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>InitCommand.php</strong><dd><code>Simplify project initialization by removing error handling for <br>defaults</code></dd></summary>
<hr>

src/Command/InitCommand.php
<li>Removed try-catch blocks for obtaining git remote URL and project <br>directory name.<br> <li> Now directly runs shell commands, which may throw exceptions if they <br>fail.<br> <li> Changed default project name prompt to a static string <br><code>'default_project_name'</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-f8710a9faec14ebc29fef72dfeda3871ae5e40f81f56c114f4b54767e6d6cf7a">+4/-15</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainCommand.php</strong><dd><code>Use repository URL instead of hash in telemetry data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Command/MainCommand.php
<li>Changed <code>project_hash</code> telemetry field to use the repository URL <br>directly instead of its SHA1 hash.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-8558493b7152a73eb3ba31b63463fcb735f23d4af82de6e982c39df5a040ff21">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Collection.php</strong><dd><code>Add explicit return after value removal in collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Collection/Collection.php
<li>Added an explicit <code>return</code> after unsetting a value in the <code>remove</code> method.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-3343f11d96cf3c9728f1cdb9ebd3b00d6cfa51907102ffd6366e4ea8779e22b0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>DocGen.php</strong><dd><code>Use relative paths for generated documentation links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Documentation/DocGen.php
<li>Changed generated documentation links to use relative paths instead of <br><code>/docs/</code> prefix.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-890c0050f97a8aa56915a9645347d6379f7194fe26558b7ba3d4ffc984096105">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TimeoutException.php</strong><dd><code>Simplify timeout exception message format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Exception/TimeoutException.php
<li>Simplified timeout exception message to only state the command timed <br>out, removing the timeout duration.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-a723ff452c53b25b93c9fafc62629b5b0089cdbee89a86ff6bc344454df0c3bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Httpie.php</strong><dd><code>Remove pretty print from JSON body encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Utility/Httpie.php
<li>Changed JSON encoding in <code>jsonBody</code> method to remove pretty print <br>formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/3/files#diff-fe202bb28729e2a10300c54933376dbce34d041a0fe3e48ecc2f266e9834bd89">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected logic for removing elements from collections to prevent unnecessary exceptions.
	- Fixed telemetry environment variable handling for improved data reporting.
	- Updated error message when no hosts are configured for better clarity.
- **Improvements**
	- Simplified default project name and repository detection during initialization.
	- Changed telemetry data to send the raw repository string instead of a hash.
	- Updated documentation links to use relative paths for easier navigation.
	- Simplified timeout exception messages for clarity.
	- Spinner animation now displays a static symbol instead of animating.
	- JSON bodies are now sent in a compact format without pretty-printing.
- **Other Changes**
	- Added a large debug array allocation during client request handling (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW  
- Main purpose: Address bugs, refine telemetry configuration logic, simplify error messages, and adjust documentation hyperlink structures.  
- Type of changes: Bug fixes, configuration logic adjustments, refactoring, and minor feature tweaks.  

---

## 🛠️ TECHNICAL DETAILS  
- **src/Collection/Collection.php**:  
  - **Bug Fix**: Modified `remove()` to exit early after unsetting an element, preventing unnecessary exception throws when the element exists.  
  - **API Change**: Ensures exceptions are only thrown when the element is not found, aligning behavior with intended logic.  

- **src/Command/CommandCommon.php**:  
  - **Logic Inversion**: Changed telemetry suppression condition to disable tracking only when `DO_NOT_TRACK` is explicitly set to `"false"` (previously triggered on `"true"`).  
  - **Environment Variable Dependency**: Relies on the same `getenv()` check but alters its semantic meaning.  

- **src/Command/MainCommand.php**:  
  - **Telemetry Data Adjustment**: Removed `sha1()` hashing from `project_hash`, now using raw repository strings.  
  - **No New Dependencies**: Maintains existing telemetry infrastructure without introducing new libraries.  

- **src/Command/SelectCommand.php**:  
  - **Error Message Refactor**: Updated exception message from "No host configured" to "Hosts are configured" (likely a typo correction).  
  - **No Functional Change**: Retains the same condition checks and exception logic.  

- **src/Documentation/DocGen.php**:  
  - **URL Simplification**: Removed hardcoded `/docs/` prefix from generated hyperlinks, relying on `$md` and `$anchor` variables.  
  - **No External Dependencies**: Pure string manipulation within existing methods.  

- **src/Exception/TimeoutException.php**:  
  - **Message Refactoring**: Removed dynamic timeout duration from exception messages, using a generic "timed out" string.  
  - **API Change**: Alters exception message format, potentially affecting downstream logging/parsing systems.  

---

## 🏗️ ARCHITECTURAL IMPACT  
- **No New Patterns/Abstractions**: Changes are localized to existing methods without introducing new architectural layers.  
- **Coupling**:  
  - Telemetry configuration logic remains tightly coupled to environment variables.  
  - `TimeoutException` message format change may impact systems parsing exception details.  
- **Configuration Sensitivity**:  
  - `CommandCommon.php` now inverts `DO_NOT_TRACK` logic, requiring documentation updates to avoid misconfiguration.  

---

## 🚀 IMPLEMENTATION HIGHLIGHTS  
- **Algorithms/Data Structures**:  
  - **Early Return**: `Collection::remove()` uses control flow optimization to exit immediately after deletion.  
  - **String Manipulation**: `DocGen::gen()` employs simple string replacement for hyperlink generation.  

- **Performance**:  
  - **Minor Improvement**: Early return in `remove()` avoids redundant code execution post-element deletion.  
  - **Telemetry Overhead**: Removing `sha1()` in `MainCommand` reduces cryptographic computation for `project_hash`.  

- **Security**:  
  - **Telemetry Data Exposure**: Raw repository strings in `project_hash` may expose identifiable data (previously hashed).  
  - **Error Message Hardening**: Timeout exceptions now omit sensitive timeout durations, reducing info leakage.  

- **Error Handling**:  
  - **Corrected Logic**: `Collection::remove()` now accurately throws exceptions only when elements are missing.  
  - **Consistency**: SelectCommand’s error message correction ensures clarity in host configuration errors.


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->