### PR TITLE
 added a file

### DIFF
--- a/src/Command/synopsisCommand.php
+++ b/src/Command/synopsisCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Command;
+
+use Deployer\Deployer;
+use Deployer\Support\Reporter;
+
+trait CommandCommon
+{
+    /**
+     * Collecting anonymous stat helps Deployer team improve developer experience.
+     * If you are not comfortable with this, you will always be able to disable this
+     * by setting DO_NOT_TRACK environment variable to `1`.
+     * @codeCoverageIgnore
+     */
+    protected function telemetry(array $data = []): void
+    {
+        if (getenv('DO_NOT_TRACK') === 'true') {
+            return;
+        }
+        try {
+            Reporter::report(array_merge([
+                'command_name' => $this->getName(),
+                'deployer_version' => DEPLOYER_VERSION,
+                'deployer_phar' => Deployer::isPharArchive(),
+                'php_version' => phpversion(),
+                'os' => defined('PHP_OS_FAMILY') ? PHP_OS_FAMILY : (stristr(PHP_OS, 'DAR') ? 'OSX' : (stristr(PHP_OS, 'WIN') ? 'WIN' : (stristr(PHP_OS, 'LINUX') ? 'LINUX' : PHP_OS))),
+            ], $data));
+        } catch (\Throwable $e) {
+            return;
+        }
+    }
+
+}


### PR DESCRIPTION
## **CodeAnt-AI Description**
- Introduced a new `CommandCommon` trait in the `Deployer\Command` namespace.
- Added a `telemetry` method to collect and report anonymous usage statistics, with an opt-out via the `DO_NOT_TRACK` environment variable.
- The telemetry data includes command name, deployer version, PHP version, and operating system details.
- Implemented robust error handling to ensure telemetry failures do not affect command execution.

This PR adds a reusable trait for anonymous telemetry reporting to help improve the developer experience by collecting usage data. The feature is privacy-conscious, allowing users to easily opt out, and is designed to be safely integrated into command classes.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>synopsisCommand.php</strong><dd><code>Introduce CommandCommon trait with telemetry reporting functionality</code></dd></summary>
<hr>

src/Command/synopsisCommand.php
<li>Added a new <code>CommandCommon</code> trait containing a <code>telemetry</code> method for <br>anonymous usage reporting.<br> <li> Implemented logic to collect and send telemetry data unless the <br><code>DO_NOT_TRACK</code> environment variable is set.<br> <li> Included error handling to silently ignore exceptions during telemetry <br>reporting.<br> <li> Provided detailed metadata collection (command name, deployer version, <br>PHP version, OS, etc.).<br>


</details>


  </td>
  <td><a href="https://github.com/jayanth-org1/deployer-php/pull/6/files#diff-c0300e2f893c2bc01caa60c6ee16e7da2551d37cfb7f900352556d08c36027aa">+42/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced anonymous usage statistics collection to help improve the Deployer tool. Telemetry respects user privacy and can be disabled by setting the `DO_NOT_TRACK` environment variable. Data collection does not disrupt normal usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack

## Sequence Diagram
```mermaid
sequenceDiagram
    participant Command
    participant Reporter

    Command->>Command: executeCommand()
    activate Command

    Command->>Command: check DO_NOT_TRACK env
    alt DO_NOT_TRACK not set
        Command->>Command: collect system data and parameters
        Command->>Reporter: report(data)
        activate Reporter
        Reporter-->>Command: (response)
        deactivate Reporter
    end
    deactivate Command
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->